### PR TITLE
Handle recommendations for non-existing items gracefully

### DIFF
--- a/lib/recommendify/similarity_matrix.rb
+++ b/lib/recommendify/similarity_matrix.rb
@@ -44,6 +44,7 @@ class Recommendify::SimilarityMatrix
   # use activesupport's orderedhash?
   def retrieve_item(item_id)
     data = Recommendify.redis.hget(redis_key, item_id)
+    return {} if data.nil?
     Hash[data.split("|").map{ |i| (k,s=i.split(":")) && [k,s.to_f] }]
   end
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -133,6 +133,11 @@ describe Recommendify::Base do
       sm.similarity_matrix.should_receive(:[]).with("fnorditem").and_return({:fooitem => 0.4, :baritem => 1.5})
       sm.for("fnorditem").length.should == 2
     end
+    
+    it "should not throw exception for non existing items" do
+      sm = Recommendify::Base.new
+      sm.for("not_existing_item").length.should == 0
+    end
 
     it "should retrieve the n-most similar neighbors as Recommendify::Neighbor objects" do
       sm = Recommendify::Base.new


### PR DESCRIPTION
Previously when you try to get recommendations for non-existing items - you would get an exception "undefined method `split' for nil:NilClass".

Now you just get an empty array.
