### PR TITLE
Allow specifying a custom similarity matrix redis key

### DIFF
--- a/lib/recommendify/base.rb
+++ b/lib/recommendify/base.rb
@@ -26,6 +26,14 @@ class Recommendify::Base
     @similarity_matrix || :similarities
   end
 
+  def self.redis_prefix(name)
+    @redis_prefix = name
+  end
+
+  def self.redis_prefix_value
+    @redis_prefix || "recommendify"
+  end
+
   def initialize    
     @input_matrices = Hash[self.class.input_matrices.map{ |key, opts| 
       opts.merge!(:key => key, :redis_prefix => redis_prefix)
@@ -39,7 +47,7 @@ class Recommendify::Base
   end
 
   def redis_prefix
-    "recommendify"
+    self.class.redis_prefix_value
   end
 
   def max_neighbors

--- a/lib/recommendify/base.rb
+++ b/lib/recommendify/base.rb
@@ -18,6 +18,14 @@ class Recommendify::Base
     @@input_matrices
   end
 
+  def self.similarity_matrix(name)
+    @similarity_matrix = name
+  end
+
+  def self.similarity_matrix_key
+    @similarity_matrix || :similarities
+  end
+
   def initialize    
     @input_matrices = Hash[self.class.input_matrices.map{ |key, opts| 
       opts.merge!(:key => key, :redis_prefix => redis_prefix)
@@ -25,7 +33,7 @@ class Recommendify::Base
     }]
     @similarity_matrix = Recommendify::SimilarityMatrix.new(
       :max_neighbors => max_neighbors,
-      :key => :similarities,
+      :key => self.class.similarity_matrix_key,
       :redis_prefix => redis_prefix
     )
   end

--- a/recommendify.gemspec
+++ b/recommendify.gemspec
@@ -4,7 +4,7 @@ $:.push File.expand_path("../lib", __FILE__)
 Gem::Specification.new do |s|
   s.name        = "recommendify"
   s.version     = "0.3.8"
-  s.date        = Time.now.strftime("%Y/%m/%d")
+  s.date        = Time.now.strftime("%Y-%m-%d")
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Paul Asmuth"]
   s.email       = ["paul@paulasmuth.com"]

--- a/recommendify.gemspec
+++ b/recommendify.gemspec
@@ -4,7 +4,7 @@ $:.push File.expand_path("../lib", __FILE__)
 Gem::Specification.new do |s|
   s.name        = "recommendify"
   s.version     = "0.3.8"
-  s.date        = Date.today.to_s
+  s.date        = Time.now.strftime("%Y/%m/%d")
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Paul Asmuth"]
   s.email       = ["paul@paulasmuth.com"]


### PR DESCRIPTION
I wanted to have multiple recommenders in my app. They were overwriting each other (both at recommendify:similarities) when I'd process them, so I added the ability to customize the similarity matrix redis key per-recommender base class. Retain default of "similarities".
