### PR TITLE
Performance improvement in add_set

### DIFF
--- a/lib/recommendify/cc_matrix.rb
+++ b/lib/recommendify/cc_matrix.rb
@@ -9,12 +9,15 @@ module Recommendify::CCMatrix
 
   def add_set(set_id, item_ids)
     # FIXPAUL: forbid | and : in item_ids
+
     item_ids.each do |item_id|
       item_count_incr(item_id)
     end
-    all_pairs(item_ids).map do |pair| 
-      i1, i2 = pair.split(":") 
-      ccmatrix.incr(i1, i2)
+    Recommendify.redis.pipelined do
+      all_pairs(item_ids).map do |pair| 
+        i1, i2 = pair.split(":") 
+        ccmatrix.incr(i1, i2)
+      end
     end
   end
 


### PR DESCRIPTION
I noticed that CCMatrix#add_set was taking a very long time. The culprit was all the increment calls for each pair that were generating tons of activity on the redis connection.  By encapsulating them in a pipeline, add_set executes 2-3 times faster.
