### PR TITLE
redis_prefix correction with tests passing

### DIFF
--- a/lib/recommendify/base.rb
+++ b/lib/recommendify/base.rb
@@ -11,7 +11,8 @@ class Recommendify::Base
   end
 
   def self.input_matrix(key, opts)
-    @@input_matrices[key] = opts
+    @@input_matrices[self.to_s] = {} if @@input_matrices[self.to_s].nil?
+    @@input_matrices[self.to_s][key] = opts
   end
 
   def self.input_matrices
@@ -19,7 +20,7 @@ class Recommendify::Base
   end
 
   def initialize    
-    @input_matrices = Hash[self.class.input_matrices.map{ |key, opts| 
+    @input_matrices = Hash[self.class.input_matrices[self.class.to_s].map{ |key, opts| 
       opts.merge!(:key => key, :redis_prefix => redis_prefix)
       [ key, Recommendify::InputMatrix.create(opts) ]
     }]

--- a/lib/recommendify/base.rb
+++ b/lib/recommendify/base.rb
@@ -20,6 +20,7 @@ class Recommendify::Base
   end
 
   def initialize    
+    @@input_matrices[self.class.to_s] = {} if @@input_matrices[self.class.to_s].nil?
     @input_matrices = Hash[self.class.input_matrices[self.class.to_s].map{ |key, opts| 
       opts.merge!(:key => key, :redis_prefix => redis_prefix)
       [ key, Recommendify::InputMatrix.create(opts) ]

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -24,7 +24,8 @@ describe Recommendify::Base do
 
     it "should add an input_matrix by 'key'" do
       Recommendify::Base.input_matrix(:myinput, :similarity_func => :jaccard)
-      Recommendify::Base.send(:class_variable_get, :@@input_matrices).keys.should == [:myinput]
+      Recommendify::Base.send(:class_variable_get, :@@input_matrices).keys.should == [ "Recommendify::Base" ]
+      Recommendify::Base.send(:class_variable_get, :@@input_matrices)["Recommendify::Base"].keys.should == [:myinput]
     end
 
     it "should retrieve an input_matrix on a new instance" do


### PR DESCRIPTION
When using multiple recommenders in a script, eg for cross validation,
the redis_prefix was the same for input matrices of all recommenders.
What's more, all recommenders had access to all input matrices of all
other recommenders.
This patch fixes these problems and enables testing 2 different
recommenders in a script to see if their difference of performance is
statistically significant.

Tests really pass now
